### PR TITLE
Define Cache interface

### DIFF
--- a/webmock/cache.go
+++ b/webmock/cache.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+type Cache interface {
+	Save(reqBody []byte, req *http.Request, respBody []byte, resp *http.Response) error
+}
+
 func createCache(body string, b []byte, req *http.Request, resp *http.Response, s *Server) error {
 	var (
 		root = s.config.cacheDir + "/"

--- a/webmock/cache.go
+++ b/webmock/cache.go
@@ -9,6 +9,7 @@ import (
 
 type Cache interface {
 	Save(reqBody []byte, req *http.Request, respBody []byte, resp *http.Response) error
+	Find(req *http.Request) (*http.Response, error)
 }
 
 func createCache(body string, b []byte, req *http.Request, resp *http.Response, s *Server) error {

--- a/webmock/context.go
+++ b/webmock/context.go
@@ -1,38 +1,7 @@
 package webmock
 
-import (
-	"io/ioutil"
-	"net/http"
-	"net/url"
-)
-
 type Context struct {
-	Req *Req
-}
-
-type Req struct {
-	Method string
-	URL    *url.URL
-	Proto  string
-	Header http.Header
-	Body   []byte
-}
-
-func NewReq(r *http.Request) (*Req, error) {
-	req := new(Req)
-	req.Method = r.Method
-	req.URL = r.URL
-	req.Proto = r.Proto
-	req.Header = make(http.Header, len(r.Header))
-	for k, vs := range r.Header {
-		for _, v := range vs {
-			req.Header.Add(k, v)
-		}
-	}
-	var err error
-	req.Body, err = ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-	return req, nil
+	// RequestBody saves request body as byte buffer.
+	// goproxy.ProxyCtx has Req field, so we do not need to save *http.Request itself.
+	RequestBody []byte
 }

--- a/webmock/dbcache.go
+++ b/webmock/dbcache.go
@@ -1,0 +1,57 @@
+package webmock
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/jinzhu/gorm"
+)
+
+type dbCache struct {
+	db *gorm.DB
+}
+
+func NewDBCache(db *gorm.DB) Cache {
+	return &dbCache{db: db}
+}
+
+func (dc *dbCache) Save(reqBody []byte, req *http.Request, respBody []byte, resp *http.Response) error {
+	url := req.URL.Host + req.URL.Path
+
+	reqStruct, err := requestStruct(string(reqBody), req)
+	if err != nil {
+		return err
+	}
+	respStruct, err := responseStruct(respBody, resp)
+	if err != nil {
+		return err
+	}
+	conn := Connection{Request: reqStruct, Response: respStruct, RecordedAt: resp.Header.Get("Date")}
+	conns := []Connection{conn}
+	endpoint := &Endpoint{
+		URL:         url,
+		Connections: conns,
+		Update:      time.Now(),
+	}
+	ce := readEndpoint(url, dc.db)
+	if len(ce.Connections) != 0 {
+		for _, v := range ce.Connections {
+			deleteConnection(&v, dc.db)
+			if v.Request.Method == req.Method {
+				continue
+			}
+			conns = append(conns, v)
+		}
+		endpoint.Connections = conns
+		updateEndpoint(ce, endpoint, dc.db)
+
+		log.Printf("[INFO] Update HTTP/S connection cache.")
+		return nil
+	}
+	if err := insertEndpoint(endpoint, dc.db); err != nil {
+		return err
+	}
+	log.Printf("[INFO] Create HTTP/S connection cache.")
+	return nil
+}

--- a/webmock/dbcache.go
+++ b/webmock/dbcache.go
@@ -61,7 +61,7 @@ func (dc *dbCache) Save(reqBody []byte, req *http.Request, respBody []byte, resp
 func (dc *dbCache) Find(req *http.Request) (*http.Response, error) {
 	reqBody, err := ioReader(req.Body)
 	if err != nil {
-		log.Printf("[ERROR] %v", err)
+		return nil, errors.Wrap(err, "failed to read request body")
 	}
 	endpoint := findEndpoint(req.Method, req.URL.Host+req.URL.Path, dc.db)
 	if len(endpoint.Connections) == 0 {

--- a/webmock/filecache.go
+++ b/webmock/filecache.go
@@ -1,0 +1,42 @@
+package webmock
+
+import (
+	"log"
+	"net/http"
+	"path/filepath"
+)
+
+type fileCache struct {
+	root string
+}
+
+func NewFileCache(root string) Cache {
+	return &fileCache{root: root}
+}
+
+func (fc *fileCache) Save(reqBody []byte, req *http.Request, respBody []byte, resp *http.Response) error {
+	var (
+		url  = req.URL.Host + req.URL.Path
+		file = req.Method + ".json"
+		dst  = filepath.Join(fc.root, url, file)
+	)
+
+	reqStruct, err := requestStruct(string(reqBody), req)
+	if err != nil {
+		return err
+	}
+	respStruct, err := responseStruct(respBody, resp)
+	if err != nil {
+		return err
+	}
+	conn := Connection{Request: reqStruct, Response: respStruct, RecordedAt: resp.Header.Get("Date")}
+	byteArr, err := structToJSON(conn)
+	if err != nil {
+		return err
+	}
+	if err := writeFile(string(byteArr), dst); err != nil {
+		return err
+	}
+	log.Printf("[INFO] Create HTTP/S connection cache.")
+	return nil
+}

--- a/webmock/filecache.go
+++ b/webmock/filecache.go
@@ -1,6 +1,7 @@
 package webmock
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -39,4 +40,8 @@ func (fc *fileCache) Save(reqBody []byte, req *http.Request, respBody []byte, re
 	}
 	log.Printf("[INFO] Create HTTP/S connection cache.")
 	return nil
+}
+
+func (fc *fileCache) Find(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented yet")
 }


### PR DESCRIPTION
To abstract backends of cache functionality, defined `Cache` interface that responds to save requests and responses in cache and find responses from cache.
Currently, we have 2 backends (file and sqlite3).
This PR just defines `Cache` and splits file and sqlite3 backends into 2 structs, but there are some duplicated code for now.